### PR TITLE
docs: add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+PhoenixBoot is a UEFI Secure Boot defense system (bash + Python). The primary interface is `./pf.py <task>` which delegates to the `pf` task runner (installed from [pf-runner](https://github.com/P4X-ng/pf-runner)). Task definitions live in `.pf` files (`core.pf`, `secure.pf`, `workflows.pf`, `maint.pf`).
+
+### Running services and tasks
+
+- **Task runner**: `./pf.py list` shows all available tasks. `pf` must be on `PATH` (installed to `~/.local/bin/pf`).
+- **Build pipeline**: `pf build-setup` (toolchain check) → `pf build-build` (uses prebuilt EFI binaries in `staging/boot/`) → ESP packaging. The build-build step does NOT create `out/staging/`; you must manually copy: `mkdir -p out/staging && cp staging/boot/NuclearBootEdk2.efi out/staging/BootX64.efi && cp staging/boot/KeyEnrollEdk2.efi out/staging/ && cp staging/boot/UUEFI.efi out/staging/`.
+- **Key generation**: `pf secure-keygen` creates keys in `keys/`. Keys are needed before ESP packaging (for signing with `sbsign`).
+- **ESP packaging**: The `scripts/esp-packaging/esp-package.sh` has a path bug — `cd "$(dirname "$0")/.."` lands in `scripts/` instead of the project root, so `source scripts/lib/common.sh` fails. Workaround: source `scripts/lib/common.sh` directly from project root and run ESP steps inline, or use `create-secureboot-bootable-media.sh` which handles paths correctly.
+- **QEMU testing**: `pf test-qemu` requires an ESP image at `out/esp/esp.img` and OVMF paths at `out/esp/ovmf_paths.txt`. KVM is not available in cloud VMs — run QEMU with `-cpu max` instead of `-cpu host -enable-kvm`. The test passes when "PhoenixGuard" appears in `out/qemu/serial.log`.
+
+### Lint and test
+
+- **Lint**: `black --check .` and `flake8 --max-line-length 120 utils/` (see `CONTRIBUTING.md`).
+- **Tests**: `utils/test_efi_parser.py` depends on a missing `efi_parser` module (not runnable). `utils/test_integration.py` requires compiled C libraries (`libpgmodverify.so`) and cert directories — integration-level only. Shell-based tests exist in `tests/` and `scripts/testing/`.
+- **Python utilities**: Import-testable via `python3 -c "from utils.<module> import ..."`. Kernel profiler, firmware checksum DB, and TUI all work.
+
+### System dependencies
+
+The following system packages are required: `qemu-system-x86`, `ovmf`, `mtools`, `dosfstools`, `openssl`, `sbsigntool`, `efitools`, `mokutil`, `gcc`, `parted`.
+
+### Key caveats
+
+- `pf` (the task runner) is NOT a pip package. It is cloned from `https://github.com/P4X-ng/pf-runner` and the `pf-cli-base/pf_parser.py` file is installed as `~/.local/bin/pf` with shebang `#!/usr/bin/env python3`. It requires `fabric` and `lark` pip packages.
+- `$HOME/.local/bin` must be on `PATH` for pip-installed scripts and the `pf` runner to work.
+- The cloud VM does not have `/dev/kvm`, so QEMU tests must omit `-enable-kvm` and `-cpu host`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ PhoenixBoot is a UEFI Secure Boot defense system (bash + Python). The primary in
 
 ### Lint and test
 
-- **Lint**: `black --check .` and `flake8 --max-line-length 120 utils/` (see `CONTRIBUTING.md`).
+- **Lint**: `black --check .` and `flake8 --max-line-length 100 utils/` (see `CONTRIBUTING.md`).
 - **Tests**: `utils/test_efi_parser.py` depends on a missing `efi_parser` module (not runnable). `utils/test_integration.py` requires compiled C libraries (`libpgmodverify.so`) and cert directories — integration-level only. Shell-based tests exist in `tests/` and `scripts/testing/`.
 - **Python utilities**: Import-testable via `python3 -c "from utils.<module> import ..."`. Kernel profiler, firmware checksum DB, and TUI all work.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Adds `AGENTS.md` with Cursor Cloud specific instructions for setting up and running the PhoenixBoot development environment. This file captures non-obvious caveats and gotchas discovered during environment setup so future cloud agents can safely start services.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

The full development environment was set up and verified:
- **Lint**: `black --check` and `flake8` run successfully against Python code
- **Build pipeline**: `pf build-setup` (toolchain check) and `pf build-build` (artifact verification) pass
- **Key generation**: `pf secure-keygen` generates SecureBoot keys
- **ESP packaging**: ESP image built with signed UEFI bootloader
- **QEMU boot test**: PhoenixGuard Nuclear Boot 1.0.0 boots successfully in QEMU (without KVM, using `-cpu max`), confirmed by "PhoenixGuard" marker in serial output
- **Python utilities**: `kernel_config_profiles.py`, `firmware_checksum_db.py`, and TUI app import/run correctly

QEMU serial log showing successful boot:
[qemu_boot_serial.log](https://cursor.com/agents/bc-d3e712a3-3dda-4e86-b753-ab990374eaaa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqemu_boot_serial.log)

## Integration Instructions

N/A - documentation only change.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3e712a3-3dda-4e86-b753-ab990374eaaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3e712a3-3dda-4e86-b753-ab990374eaaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

